### PR TITLE
Bug: Tags does not written in ComicInfo.xml (include solution)

### DIFF
--- a/pycbzhelper/comicinfo.py
+++ b/pycbzhelper/comicinfo.py
@@ -3,7 +3,7 @@ KEYS_STRING = [
     "Summary", "Notes", "Writer", "Penciller", "Inker", "Colorist",
     "Letterer", "CoverArtist", "Editor", "Publisher", "Imprint", "Genre",
     "Web", "Characters", "Teams", "Locations", "ScanInformation",
-    "StoryArc", "SeriesGroup", "CommunityRating"
+    "StoryArc", "SeriesGroup", "CommunityRating", "Tags"
 ]
 
 KEYS_INT = [


### PR DESCRIPTION
I found bug that `Tags` is not written in `ComicInfo.xml`.
It is because that `KEYS_STRING` does not have `Tags` so `Helper._comic_info` does not write it.

So I add `Tags` into `KEYS_STRING` and `Tags` is properly written in `ComicInfo.xml`

Would you merge this PR and release new version of package to pypi?

Thanks